### PR TITLE
removed hard coded slack token file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,24 @@ from IRC even after they shut down their IRC gateway.
 Obtaining token
 ===============
 
-Instructions for chromium, probably similar for other browsers.
+Instructions for chromium
 
 * In your browser, go to "Inspect" (developer mode) on an empty page
 * Select the "Network" tab.
 * Select WS (WebSockets)
 * Open your web slack client
 * Copy the 'token' parameter from the WebSocket connection URL.
+* Place the token inside '~/.localslackcattoken'
 
-Now you can use localslackirc.
+Instructions for firefox
+
+* In your browser, open the Slack web client
+* Press F12 to open the developer tools
+* Refresh the page (F5)
+* Select the 'Network' tab
+* Select the 'WS' tab
+* Copy the 'token' parameter from the WebSocket connection URL.
+* Place the token inside '~/.localslackcattoken'
 
 IRC Channel
 ===========

--- a/slack.py
+++ b/slack.py
@@ -25,6 +25,7 @@ from typing import *
 from slackclient import SlackClient
 from typedload import load
 
+from os.path import expanduser
 
 class ResponseException(Exception):
     pass
@@ -148,9 +149,12 @@ SlackEvent = Union[
 
 class Slack:
     def __init__(self) -> None:
-        #FIXME open the token in a sensible way
-        with open('/home/salvo/.localslackcattoken') as f:
-            token = f.readline().strip()
+        home = expanduser("~")
+        try:
+            with open(home + '/.localslackcattoken') as f:
+                token = f.readline().strip()
+        except FileNotFoundError:
+            exit("Slack token file not found")
         self.client = SlackClient(token)
         self._usercache = {}  # type: Dict[str, User]
         self._usermapcache = {}  # type: Dict[str, User]


### PR DESCRIPTION
Now uses ~/.slackcattoken. Also exists gracefully on file not found.

Added firefox specific instructions for obtaining the token as well as explaining what file to put it in.
