### PR TITLE
user mention fixes, support for multiple skype clients

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -201,8 +201,6 @@ class Client:
         """
         if hasattr(sl_ev, 'user'):
             source = self.sl_client.get_user(sl_ev.user).name.encode('utf8')
-            if source == self.nick:
-                return
         else:
             source = b'bot'
         try:

--- a/irc.py
+++ b/irc.py
@@ -24,6 +24,9 @@ import argparse
 from typing import *
 from os.path import expanduser
 
+from logger import logger
+from logger import startlog
+from logger import searchlog
 import slack
 
 
@@ -88,6 +91,8 @@ class Client:
         msg = msg[1:]
         message = self._addmagic(msg.decode('utf8'))
 
+        # Save outgoing messages to log file.
+        logger(self.nick.decode('utf-8'), message)
         if dest.startswith(b'#'):
             self.sl_client.send_message(
                 self.sl_client.get_channel_by_name(dest[1:].decode()).id,
@@ -208,11 +213,22 @@ class Client:
             print('Error: ', str(e))
             return
         for msg in self.parse_message(prefix + sl_ev.text):
-            self.sendmsg(
-                source,
-                dest,
-                msg
-            )
+            if source != self.nick:
+                self.sendmsg(
+                    source,
+                    dest,
+                    msg
+                )
+            else:
+                # Review log file and see if this is a new message.
+                if searchlog(source.decode('utf-8'), msg.decode('utf-8')):
+                    return
+                else:
+                    self.sendmsg(
+                        source,
+                        dest,
+                        msg
+                    )
 
     def slack_event(self, sl_ev):
         #TODO handle p2p messages
@@ -299,6 +315,8 @@ def main():
 
     poller = select.poll()
 
+    # open a chat log file.
+    startlog()
     while True:
         s, _ = serversocket.accept()
         ircclient = Client(s, sl_client, args.nouserlist)

--- a/irc.py
+++ b/irc.py
@@ -27,8 +27,8 @@ from os.path import expanduser
 from logger import logger
 from logger import startlog
 from logger import searchlog
-import slack
 
+import slack
 
 # How slack expresses mentioning users
 _MENTIONS_REGEXP = re.compile(r'<@([0-9A-Za-z]+)>')
@@ -139,6 +139,9 @@ class Client:
             ))
         self.s.send(b':serenity 315 %s %s :End of WHO list\n' % (self.nick, name))
 
+    def _ignorehandler(self, cmd: bytes) -> None:
+        pass
+
     def sendmsg(self, from_: bytes, to: bytes, message: bytes) -> None:
         self.s.send(b':%s!salvo@127.0.0.1 PRIVMSG %s :%s\n' % (
             from_,
@@ -160,7 +163,7 @@ class Client:
         # Extremely inefficient code to generate mentions
         # Just doing them client-side on the receiving end is too mainstream
         for username in self.sl_client.get_usernames():
-            if username in msg:
+            if "{} ".format(username) in msg:
                 msg = msg.replace(
                     username,
                     '<@%s>' % self.sl_client.get_user_by_name(username).id
@@ -263,6 +266,8 @@ class Client:
             b'LIST': self._listhandler,
             b'WHO': self._whohandler,
             b'MODE': self._modehandler,
+            # ISON - Old command, successor is the WATCH command.
+            b'ISON': self._ignorehandler,
             #QUIT
             #CAP LS
             #USERHOST

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+#
+# This file contains logging support for localslackirc
+#
+# Like localslackirc this is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# author Hack5190
+
+def startlog():
+    """
+    open a chat log file. if it exists zero it out and start fresh.
+    """
+    with open("ircchat.log", "w") as temp:
+        temp.write("")
+
+
+def logger(name, msg):
+    """
+    log localslackirc users chat messages.
+    """
+    # load the contents of the chat log.  This needs improvement.
+    irclog = open("ircchat.log", 'r')
+    content = irclog.readlines()
+    irclog.close()
+
+    # loop through the content of the chat log and save the most recent 20. This needs improvement.
+    irclog = open("ircchat.log", "w")
+    while len(content) > 20:
+        content.remove(content[0])
+    if len(content) > 0:
+        for i in content:
+            irclog.write(i.strip('\n\r') + '\n')
+
+    # write current messge to log.
+    #irclog.write(name + ':' + msg)
+    irclog.write(msg)
+    irclog.close()
+
+
+def searchlog(name, msg):
+    """
+    loop through the chat log file and search for a match.
+    """
+    with open("ircchat.log", "r") as ircchat:
+      content = ircchat.readlines()
+
+    # loop through the log and search for this message.
+    for i in content:
+        if msg in i:
+            return 1
+    # msg not found
+    return 0


### PR DESCRIPTION
Added code to ignore ISON messages from IRC client - ISON is an old command, the successor is WATCH.

Changed code to improve handling of usernames that appear in a word.  Example would be tom in tommorrow.  Username mentions now require a trailing space.

Added code to log localusers most recent 20 outbound messages.  This allows incoming messages from the local user sent via other Slack clients to be displayed.
