### PR TITLE
Stop the automatic parsing of usernames (ie: tomorrow as @tom orrow)

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -155,7 +155,7 @@ class Client:
         # Extremely inefficient code to generate mentions
         # Just doing them client-side on the receiving end is too mainstream
         for username in self.sl_client.get_usernames():
-            if username in msg:
+            if "{} ".format(username) in msg or "{}:".format(username) in msg:
                 msg = msg.replace(
                     username,
                     '<@%s>' % self.sl_client.get_user_by_name(username).id


### PR DESCRIPTION
Requires a training space or colon for username mentions.