### PR TITLE
Add --autojoin option: force join remote chans.

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -32,7 +32,7 @@ _MENTIONS_REGEXP = re.compile(r'<@([0-9A-Za-z]+)>')
 
 
 class Client:
-    def __init__(self, s, sl_client, nouserlist):
+    def __init__(self, s, sl_client, *, nouserlist=False, autojoin=False):
         self.nick = b''
         self.username = b''
         self.realname = b''
@@ -41,6 +41,7 @@ class Client:
         self.sl_client = sl_client
         
         self.nouserlist = nouserlist
+        self.autojoin = autojoin
 
     def _nickhandler(self, cmd: bytes) -> None:
         _, nick = cmd.split(b' ', 1)
@@ -54,6 +55,17 @@ class Client:
         self.s.send(b':serenity 004 %s serenity miniircd-1.2.1 o o\n' % self.nick)
         self.s.send(b':serenity 251 %s :There are 1 users and 0 services on 1 server\n' % self.nick)
 
+        if self.autojoin:
+            for sl_chan in self.sl_client.channels():
+                if not sl_chan.is_member:
+                    continue
+
+                channel_name = '%(prefix)s%(name)s' % dict(
+                    prefix='#' if sl_chan.is_channel else '&',
+                    name=sl_chan.name_normalized,
+                )
+                self._send_chan_info(channel_name.encode('utf-8'), sl_chan)
+
     def _pinghandler(self, cmd: bytes) -> None:
         _, lbl = cmd.split(b' ', 1)
         self.s.send(b':serenity PONG serenity %s\n' % lbl)
@@ -65,6 +77,10 @@ class Client:
             slchan = self.sl_client.get_channel_by_name(channel_name[1:].decode())
         except:
             return
+
+        self._send_chan_info(channel_name, slchan)
+
+    def _send_chan_info(self, channel_name: bytes, slchan: slack.Channel):
         if not self.nouserlist:
             userlist = []  # type List[bytes]
             for i in self.sl_client.get_members(slchan.id):
@@ -282,6 +298,9 @@ def main():
     parser.add_argument('-u', '--nouserlist', action='store_true',
                                 dest='nouserlist', required=False,
                                 help='don\'t display userlist')
+    parser.add_argument('-j', '--autojoin', action='store_true',
+                                dest='autojoin', required=False,
+                                help="Automatically join all remote channels")
     parser.add_argument('-o', '--override', action='store_true',
                                 dest='overridelocalip', required=False,
                                 help='allow non 127. addresses, this is potentially dangerous')
@@ -304,7 +323,7 @@ def main():
 
     while True:
         s, _ = serversocket.accept()
-        ircclient = Client(s, sl_client, args.nouserlist)
+        ircclient = Client(s, sl_client, nouserlist=args.nouserlist, autojoin=args.autojoin)
 
         poller.register(s.fileno(), select.POLLIN)
         if sl_client.fileno is not None:

--- a/irc.py
+++ b/irc.py
@@ -60,6 +60,11 @@ class Client:
         self.s.send(b':serenity 004 %s serenity miniircd-1.2.1 o o\n' % self.nick)
         self.s.send(b':serenity 251 %s :There are 1 users and 0 services on 1 server\n' % self.nick)
 
+        if self.autojoin and not self.nouserlist:
+            # We're about to load many users for each chan; instead of requesting each
+            # profile on its own, batch load the full directory.
+            self.sl_client.prefetch_users()
+
         if self.autojoin:
 
             mpim_cutoff = datetime.datetime.utcnow() - MPIM_HIDE_DELAY

--- a/slack.py
+++ b/slack.py
@@ -301,6 +301,17 @@ class Slack:
     def get_usernames(self) -> List[str]:
         return list(self._usermapcache.keys())
 
+    def prefetch_users(self) -> None:
+        """
+        Prefetch all team members for the slack team.
+        """
+        r = self.client.api_call("users.list")
+        response = load(r, Response)
+        if response.ok:
+            for user in load(r['members'], List[User]):
+                self._usercache[user.id] = user
+                self._usermapcache[user.name] = user
+
     def get_user(self, id_: str) -> User:
         """
         Returns a user object from a slack user id

--- a/slack.py
+++ b/slack.py
@@ -74,6 +74,13 @@ class Channel(NamedTuple):
     purpose: Topic
     topic: Topic
     num_members: int = 0
+    #: Membership: present on channels, not on groups - but True there.
+    is_member: bool = True
+
+    #: Object type. groups have is_group=True, channels is_channel=True
+    is_channel: bool = False
+    is_group: bool = False
+    is_mpim: bool = False
 
     @property
     def name(self):


### PR DESCRIPTION
Notes:
- We filter out MPIMs where nobody has spoken for more than 50 days (arbitrary, this should be a config option);
- Performance is awful when used without --nouserlist: we need to fetch each and every user from the server on startup. This should be optimized in a future PR.