### PR TITLE
Sends smaller /names list.

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -18,6 +18,7 @@
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
 import datetime
+import itertools
 import re
 import select
 import socket
@@ -42,6 +43,10 @@ _SUBSTITUTIONS = [
 
 #: Inactivity days to hide a MPIM
 MPIM_HIDE_DELAY = datetime.timedelta(days=50)
+
+
+#: Max users par /names line
+MAX_NAMES_USERS = 50
 
 
 class Client:
@@ -102,8 +107,8 @@ class Client:
         self._send_chan_info(channel_name, slchan)
 
     def _send_chan_info(self, channel_name: bytes, slchan: slack.Channel):
+        userlist = []  # type List[bytes]
         if not self.nouserlist:
-            userlist = []  # type List[bytes]
             for i in self.sl_client.get_members(slchan.id):
                 try:
                     u = self.sl_client.get_user(i)
@@ -116,11 +121,12 @@ class Client:
                 prefix = b'@' if u.is_admin else b''
                 userlist.append(prefix + name)
 
-            users = b' '.join(userlist)
-
         self.s.send(b':%s!salvo@127.0.0.1 JOIN %s\n' % (self.nick, channel_name))
         self.s.send(b':serenity 332 %s %s :%s\n' % (self.nick, channel_name, slchan.real_topic.encode('utf8')))
-        self.s.send(b':serenity 353 %s = %s :%s\n' % (self.nick, channel_name, b'' if self.nouserlist else users))
+
+        for _key, group in itertools.groupby(enumerate(userlist), lambda pair: pair[0] // MAX_NAMES_USERS):
+            users = b' '.join([user for _rank, user in group])
+            self.s.send(b':serenity 353 %s = %s :%s\n' % (self.nick, channel_name, users))
         self.s.send(b':serenity 366 %s %s :End of NAMES list\n' % (self.nick, channel_name))
 
     def _privmsghandler(self, cmd: bytes) -> None:


### PR DESCRIPTION
Some clients might not expect a single line containing all 17k members
of a channel; send them by batches of 50.

Notes:
- The batch size might need some tuning
- I don't have access to a "big" slack instance, so I'd be interested in getting some testing from someone who has that access (maybe @Hack5190 ?)