### PR TITLE
replace @here and @channel mentions to be something more sane

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -235,8 +235,8 @@ class Client:
 
             encoded = i.encode('utf8')
 
-            encoded = encoded.replace(b'<!here>', b'[YELLING]' + self.nick)
-            encoded = encoded.replace(b'<!channel>', b'[YELLING]' + self.nick)
+            encoded = encoded.replace(b'<!here>', b'@here [%s]' % self.nick)
+            encoded = encoded.replace(b'<!channel>', b'@channel [%s]' % self.nick)
 
             yield encoded
 


### PR DESCRIPTION
[YELLING] isn't all that descriptive, in my use case I need to know if it's a channel or here @.

Now it looks like "@here/channel [yourname] message here"