### PR TITLE
catch unhandled exception in whohandler

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -202,7 +202,10 @@ class Client:
         if not name.startswith(b'#'):
             print('WHO not supported on ', name)
             return
-        channel = self.sl_client.get_channel_by_name(name.decode()[1:])
+        try:
+            channel = self.sl_client.get_channel_by_name(name.decode()[1:])
+        except KeyError:
+            return;
 
         for i in self.sl_client.get_members(channel.id):
             user = self.sl_client.get_user(i)


### PR DESCRIPTION
KeyError is raised when a channel requested isn't found, a user can cause this by issuing /who #nonexistingchannel