### PR TITLE
NAMES reply line length can exceed IRC spec

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -150,7 +150,7 @@ class Client:
         replies = []  # type List[bytes]
         if not self.nouserlist:
             overhead = self._getreplyoverhead(Replies.RPL_NAMREPLY, ['=', channel_name])
-            reply = []
+            reply: List[bytes] = []
             for i in self.sl_client.get_members(slchan.id):
                 try:
                     u = self.sl_client.get_user(i)


### PR DESCRIPTION
I am connecting to this app using ZNC as an IRC client, on joining a Slack instance with many members, ZNC disconnects with an error saying it received a too long line from the IRC server.

It seems that ZNC strictly follows the IRC specification in RFC 2812 and permits lines from the IRC server to be 512 bytes maximum.

So the reply to NAMES must not send lines over that length. So we need to be able to calculate the overhead added to a NAMES reply, and break up the NAMES replies over several lines so none of them are longer than 512 bytes.

This patch stops ZNC from disconnecting because of this issue, when used with my Slack instance.