### PR TITLE
Manage reconnect in one place

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -405,16 +405,24 @@ class Slack:
         """
         This yields an event or None. Don't call it without sleeps
         """
-        sleeptime = 0.1
+        sleeptime = 1
 
         while True:
             try:
                 events = self.client.rtm_read()
             except:
-                sleep(sleeptime)
-                sleeptime = 10
-                self.login_info = self.client.rtm_connect()
-                events = []
+                print('Connecting to slack...')
+                try:
+                    self.login_info = self.client.rtm_connect()
+                    sleeptime = 1
+                except:
+                    print('Connection to slack failed')
+                    sleep(sleeptime)
+                    if sleeptime <= 120:  # max reconnection interval at 2 minutes
+                        sleeptime *= 2
+                    continue
+                print('Connected to slack')
+                continue
 
             for event in events:
                 t = event.get('type')

--- a/slack.py
+++ b/slack.py
@@ -405,13 +405,15 @@ class Slack:
         """
         This yields an event or None. Don't call it without sleeps
         """
-        self.login_info = self.client.rtm_connect()
+        sleeptime = 0.1
+
         while True:
             try:
                 events = self.client.rtm_read()
             except:
-                if not self.client.rtm_connect():
-                    sleep(10)
+                sleep(sleeptime)
+                sleeptime = 10
+                self.login_info = self.client.rtm_connect()
                 events = []
 
             for event in events:

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -112,7 +112,7 @@ class SlackClient:
         # in the future, this should handle some events internally i.e. channel
         # creation
         if self.server:
-            json_data = self.server.websocket_safe_read()
+            json_data = self.server.websocket_read()
             data = []
             if json_data != '':
                 for d in json_data.split('\n'):

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -53,7 +53,7 @@ class SlackClient:
     def __init__(self, token: str, proxies: Optional[Dict[str,str]] = None) -> None:
 
         self.token = token
-        self.server = Server(self.token, False, proxies)
+        self.server = Server(self.token, proxies)
 
     def rtm_connect(self) -> LoginInfo:
         '''

--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -71,7 +71,7 @@ class Server:
         self._websocket = None  # type: Optional[WebSocket]
         self.ws_url = None
         self.connected = False
-        self._auto_reconnect = True
+        self._auto_reconnect = False
         self.last_connected_at = 0
         self.reconnect_count = 0
         self.rtm_connect_retries = 0
@@ -101,7 +101,7 @@ class Server:
 
         # rtm.start returns user and channel info, rtm.connect does not.
         connect_method = "rtm.connect"
-        self._auto_reconnect = kwargs.get('auto_reconnect', True)
+        self._auto_reconnect = kwargs.get('auto_reconnect', False)
 
         # If this is an auto reconnect, rate limit reconnect attempts
         if self._auto_reconnect and reconnect:


### PR DESCRIPTION
Remove the original reconnect code from the slack module and just do it all in one place.

Raise exceptions all over the place rather than try to hide them.