### PR TITLE
Ignore file_public

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -35,6 +35,7 @@ USELESS_EVENTS = {
     'reaction_added',
     'user_typing',
     'file_deleted',
+    'file_public',
 }
 
 


### PR DESCRIPTION
Generated on upload… let's just use the event when the files are shared on
some chat instead.