### PR TITLE
Ignore file deletion messages

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -432,7 +432,9 @@ class Slack:
                         )
                     elif t == 'message' and subt == 'message_deleted':
                         event['previous_message']['channel'] = event['channel']
-                        yield _loadwrapper(event['previous_message'], MessageDelete)
+                        ev = _loadwrapper(event['previous_message'], MessageDelete)
+                        if ev.text:  # deleting files generates empty MessageDelete events
+                            yield ev
                     elif t == 'message' and subt == 'bot_message':
                         yield _loadwrapper(event, MessageBot)
                     elif t == 'user_change':


### PR DESCRIPTION
For some obscure reason, deleting a file on slack causes a message_deleted event with
an empty text, so this ignores them.