### PR TITLE
startup: support environment variables for PORT and TOKEN.

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -439,25 +439,25 @@ def main() -> None:
                 'authentication, it\'s recommended to only allow local connections\n' \
                 'you can override this with -o')
 
-    if "PORT" in environ:
-        port = environ["PORT"]
+    if 'PORT' in environ:
+        port = int(environ['PORT'])
     else:
         port = args.port
 
-    if "TOKEN" in environ:
-        token = environ["TOKEN"]
+    if 'TOKEN' in environ:
+        token = environ['TOKEN']
     else:
         try:
             with open(args.tokenfile) as f:
                 token = f.readline().strip()
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             exit(f'Unable to open the token file {args.tokenfile}')
 
     sl_client = slack.Slack(token)
     sl_events = sl_client.events_iter()
     serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    serversocket.bind((args.ip, int(port)))
+    serversocket.bind((args.ip, port))
     serversocket.listen(1)
 
     poller = select.poll()

--- a/irc.py
+++ b/irc.py
@@ -451,7 +451,7 @@ def main() -> None:
             with open(args.tokenfile) as f:
                 token = f.readline().strip()
         except FileNotFoundError:
-            exit(f'Unable to open the token file {tokenfile}')
+            exit(f'Unable to open the token file {args.tokenfile}')
 
     sl_client = slack.Slack(token)
     sl_events = sl_client.events_iter()

--- a/irc.py
+++ b/irc.py
@@ -24,6 +24,7 @@ import select
 import socket
 import argparse
 from typing import *
+from os import environ
 from os.path import expanduser
 from socket import gethostname
 
@@ -438,11 +439,25 @@ def main() -> None:
                 'authentication, it\'s recommended to only allow local connections\n' \
                 'you can override this with -o')
 
-    sl_client = slack.Slack(args.tokenfile)
+    if "PORT" in environ:
+        port = environ["PORT"]
+    else:
+        port = args.port
+
+    if "TOKEN" in environ:
+        token = environ["TOKEN"]
+    else:
+        try:
+            with open(args.tokenfile) as f:
+                token = f.readline().strip()
+        except FileNotFoundError:
+            exit(f'Unable to open the token file {tokenfile}')
+
+    sl_client = slack.Slack(token)
     sl_events = sl_client.events_iter()
     serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    serversocket.bind((args.ip, args.port))
+    serversocket.bind((args.ip, int(port)))
     serversocket.listen(1)
 
     poller = select.poll()

--- a/slack.py
+++ b/slack.py
@@ -214,12 +214,7 @@ SlackEvent = Union[
 
 
 class Slack:
-    def __init__(self, tokenfile: str) -> None:
-        try:
-            with open(tokenfile) as f:
-                token = f.readline().strip()
-        except FileNotFoundError:
-            exit(f'Unable to open the token file {tokenfile}')
+    def __init__(self, token) -> None:
         self.client = SlackClient(token)
         self._usercache = {}  # type: Dict[str, User]
         self._usermapcache = {}  # type: Dict[str, User]

--- a/slack.py
+++ b/slack.py
@@ -214,7 +214,7 @@ SlackEvent = Union[
 
 
 class Slack:
-    def __init__(self, token) -> None:
+    def __init__(self, token: int) -> None:
         self.client = SlackClient(token)
         self._usercache = {}  # type: Dict[str, User]
         self._usermapcache = {}  # type: Dict[str, User]

--- a/slack.py
+++ b/slack.py
@@ -214,7 +214,7 @@ SlackEvent = Union[
 
 
 class Slack:
-    def __init__(self, token: int) -> None:
+    def __init__(self, token: str) -> None:
         self.client = SlackClient(token)
         self._usercache = {}  # type: Dict[str, User]
         self._usermapcache = {}  # type: Dict[str, User]


### PR DESCRIPTION
Due to the one to one mapping of service instances to listen ports /
tokens, being able to pull the most commonly adjusted config arguments
straight out of the environment will be really handy, especially for
those of us who use a lot of process supervision.

This necessitated moving token file parsing out of slack.py and into
irc.py in addition to modifications to the argument handling.

Something to keep in mind: as written this commit changes precedence so
that if PORT or TOKEN are set their corresponding optargs are ignored.
To switch that order around, add a second test to see if args.token or
args.port are set to their defaults and only apply the environment value
if the arg values are still default.