### PR TITLE
Don't prefix short nicknames with @, since the user is probably just using it as a word

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -280,6 +280,7 @@ class Client:
         # Extremely inefficient code to generate mentions
         # Just doing them client-side on the receiving end is too mainstream
         for username in self.sl_client.get_usernames():
+            if len(username) < 3: continue
             m = re.search(r'\b%s\b' % username, msg)
             if m:
                 msg = msg[0:m.start()] + '<@%s>' % self.sl_client.get_user_by_name(username).id + msg[m.end():]


### PR DESCRIPTION
For whatever reason, the slack I'm on has users named "a" and "t", so chat looks like "can'@t run @a test" without this patch.