### PR TITLE
Requires

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,7 @@ Vcs-Browser: https://github.com/ltworf/localslackirc
 
 Package: localslackirc
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3-typedload,
- python3-websocket, python3-requests
+Depends: ${misc:Depends}, ${python3:Depends}
 Description: IRC gateway for slack, running on localhost for one user
  This project is a replacement for slack's IRC gateway that they dropped.
  .

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,9 @@
 #!/usr/bin/make -f
 
+DH_VERBOSE=1
+
 %:
 	dh $@ --with python3
+
+override_dh_python3:
+	dh_python3 --requires=requirements.txt


### PR DESCRIPTION
Tell dh_python3 where the requirements are. It can't find them by itself…