### PR TITLE
Support for the new xoxc tokens

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -496,6 +496,10 @@ def main() -> None:
                                 default=expanduser('~')+'/.localslackirc',
                                 required=False,
                                 help='set the token file')
+    parser.add_argument('-c', '--cookiefile', type=str, action='store', dest='cookiefile',
+                                default=None,
+                                required=False,
+                                help='set the cookie file (for only, for xoxc tokens)')
     parser.add_argument('-u', '--nouserlist', action='store_true',
                                 dest='nouserlist', required=False,
                                 help='don\'t display userlist')
@@ -531,11 +535,25 @@ def main() -> None:
         except (FileNotFoundError, PermissionError):
             exit(f'Unable to open the token file {args.tokenfile}')
 
+    if 'COOKIE' in environ:
+        cookie: Optional[str] = environ['COOKIE']
+    else:
+        try:
+            if args.cookiefile:
+                with open(args.cookiefile) as f:
+                    cookie = f.readline().strip()
+            else:
+                cookie = None
+        except (FileNotFoundError, PermissionError):
+            exit(f'Unable to open the cookie file {args.cookiefile}')
+        except IsADirectoryError:
+            exit(f'Not a file {args.cookiefile}')
+
     if args.rc_url:
         sl_client: Union[slack.Slack, rocket.Rocket] = rocket.Rocket(args.rc_url, token)
         provider = Provider.ROCKETCHAT
     else:
-        sl_client = slack.Slack(token)
+        sl_client = slack.Slack(token, cookie)
         provider = Provider.SLACK
     sl_events = sl_client.events_iter()
     serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/irc.py
+++ b/irc.py
@@ -549,6 +549,9 @@ def main() -> None:
         except IsADirectoryError:
             exit(f'Not a file {args.cookiefile}')
 
+    if token.startswith('xoxc-') and not cookie:
+        exit('The cookie is needed for this kind of slack token')
+
     if args.rc_url:
         sl_client: Union[slack.Slack, rocket.Rocket] = rocket.Rocket(args.rc_url, token)
         provider = Provider.ROCKETCHAT

--- a/irc.py
+++ b/irc.py
@@ -499,7 +499,7 @@ def main() -> None:
     parser.add_argument('-c', '--cookiefile', type=str, action='store', dest='cookiefile',
                                 default=None,
                                 required=False,
-                                help='set the cookie file (for only, for xoxc tokens)')
+                                help='set the cookie file (for slack only, for xoxc tokens)')
     parser.add_argument('-u', '--nouserlist', action='store_true',
                                 dest='nouserlist', required=False,
                                 help='don\'t display userlist')

--- a/irc.py
+++ b/irc.py
@@ -526,6 +526,8 @@ def main() -> None:
         try:
             with open(args.tokenfile) as f:
                 token = f.readline().strip()
+        except IsADirectoryError:
+            exit(f'Not a file {args.tokenfile}')
         except (FileNotFoundError, PermissionError):
             exit(f'Unable to open the token file {args.tokenfile}')
 

--- a/man/localslackirc.1
+++ b/man/localslackirc.1
@@ -1,4 +1,4 @@
-.TH localslackirc 1 "Jul 29, 2019" "IRC gateway for slack and rocket.chat"
+.TH localslackirc 1 "Feb 27, 2020" "IRC gateway for slack and rocket.chat"
 .SH NAME
 localslackirc
 \- Creates an IRC server running locally, which acts as a gateway to slack or rocket.chat for one user.
@@ -27,6 +27,9 @@ Set the IP (Ipv4 only) address to listen to. The default is 127.0.0.1.
 .TP
 .B -t TOKENFILE, --tokenfile TOKENFILE
 Set the token file. The default is ~/.localslackirc.
+.TP
+.B -c TOKENFILE, --cookiefile TOKENFILE
+Set the cookie file. This is only used on slack, and is only useful if your token starts with "xoxc".
 .TP
 .B -u, --nouserlist
 Don't display userlist in the IRC client.

--- a/slack.py
+++ b/slack.py
@@ -233,8 +233,8 @@ SlackEvent = Union[
 
 
 class Slack:
-    def __init__(self, token: str) -> None:
-        self.client = SlackClient(token)
+    def __init__(self, token: str, cookie: Optional[str]) -> None:
+        self.client = SlackClient(token, cookie)
         self._usercache: Dict[str, User] = {}
         self._usermapcache: Dict[str, User] = {}
         self._imcache: Dict[str, str] = {}

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -36,6 +36,7 @@ from websocket._exceptions import WebSocketConnectionClosedException
 
 class SlackRequest(NamedTuple):
     token: str
+    cookie: Optional[str]
     proxies: Optional[Dict[str,str]]
 
     def do(self, request: str, post_data: Dict[str,str], timeout: Optional[float], files: Optional[Dict]):
@@ -57,6 +58,8 @@ class SlackRequest(NamedTuple):
             'user-agent': 'localslackirc',
             'Authorization': f'Bearer {self.token}'
         }
+        if self.cookie:
+            headers['cookie'] = self.cookie
 
         # Submit the request
         return requests.post(
@@ -90,11 +93,11 @@ class SlackClient:
     The SlackClient object owns the websocket connection and all attached channel information.
     """
 
-    def __init__(self, token: str, proxies: Optional[Dict[str,str]] = None) -> None:
+    def __init__(self, token: str, cookie: Optional[str], proxies: Optional[Dict[str,str]] = None) -> None:
         # Slack client configs
         self._token = token
         self._proxies = proxies
-        self._api_requester = SlackRequest(token, proxies)
+        self._api_requester = SlackRequest(token, cookie, proxies)
 
         # RTM configs
         self._websocket: Optional[WebSocket] = None

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -43,7 +43,6 @@ class SlackRequest(NamedTuple):
         Perform a POST request to the Slack Web API
 
         Args:
-            token (str): your authentication token
             request (str): the method to call from the Slack API. For example: 'channels.list'
             timeout (float): stop waiting for a response after a given number of seconds
             post_data (dict): key/value arguments to pass for the request. For example:

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -34,11 +34,11 @@ from websocket import create_connection, WebSocket
 from websocket._exceptions import WebSocketConnectionClosedException
 
 
-class SlackRequest:
-    def __init__(self, proxies: Optional[Dict[str,str]] = None) -> None:
-        self.proxies = proxies
+class SlackRequest(NamedTuple):
+    token: str
+    proxies: Optional[Dict[str,str]] = None
 
-    def do(self, token: str, request: str, post_data: Dict[str,str], timeout: Optional[float], files: Optional[Dict]):
+    def do(self, request: str, post_data: Dict[str,str], timeout: Optional[float], files: Optional[Dict]):
         """
         Perform a POST request to the Slack Web API
 
@@ -56,7 +56,7 @@ class SlackRequest:
         # Set user-agent and auth headers
         headers = {
             'user-agent': 'localslackirc',
-            'Authorization': f'Bearer {token}'
+            'Authorization': f'Bearer {self.token}'
         }
 
         # Submit the request
@@ -95,7 +95,7 @@ class SlackClient:
         # Slack client configs
         self._token = token
         self._proxies = proxies
-        self._api_requester = SlackRequest(proxies=proxies)
+        self._api_requester = SlackRequest(token, proxies)
 
         # RTM configs
         self._websocket: Optional[WebSocket] = None
@@ -115,7 +115,7 @@ class SlackClient:
 
         # rtm.start returns user and channel info, rtm.connect does not.
         connect_method = "rtm.connect"
-        reply = self._api_requester.do(self._token, connect_method, timeout=timeout, post_data=kwargs, files=None)
+        reply = self._api_requester.do(connect_method, timeout=timeout, post_data=kwargs, files=None)
 
         if reply.status_code != 200:
             raise SlackConnectionError("RTM connection attempt failed")
@@ -204,7 +204,7 @@ class SlackClient:
             files = kwargs.pop('files')
         else:
             files = None
-        response = self._api_requester.do(self._token, method, kwargs, timeout, files)
+        response = self._api_requester.do(method, kwargs, timeout, files)
         response_json = json.loads(response.text)
         response_json["headers"] = dict(response.headers)
         return response_json

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -36,7 +36,7 @@ from websocket._exceptions import WebSocketConnectionClosedException
 
 class SlackRequest(NamedTuple):
     token: str
-    proxies: Optional[Dict[str,str]] = None
+    proxies: Optional[Dict[str,str]]
 
     def do(self, request: str, post_data: Dict[str,str], timeout: Optional[float], files: Optional[Dict]):
         """


### PR DESCRIPTION
When a `xoxc` token is in use, the cookies are required too to authenticate.

The initial input for this solution comes from here: https://b17zr.com/2019/10/09/download-custom-slack-emojis/