### PR TITLE
Fix wrong name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attr
+attrs
 requests
 typedload
 websocket-client


### PR DESCRIPTION
Closes: #165

The debian and the pypi package are not named the same it seems…