### PR TITLE
Require typedload 2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ localslackirc (1.8-1) UNRELEASED; urgency=medium
   * New upstream release
   * Require python3.8 at least
   * Depend on python3-attr
+  * Bump dependency on typedload
 
  -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Sun, 01 Mar 2020 12:47:17 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>
 Build-Depends: debhelper (>= 12), python3, dh-python, python3-distutils,
- mypy, python3-typedload
+ mypy, python3-typedload (>= 2)
 Standards-Version: 4.5.0
 Homepage: https://github.com/ltworf/localslackirc
 X-Python3-Version: >= 3.8
@@ -12,7 +12,7 @@ Rules-Requires-Root: no
 
 Package: localslackirc
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3-typedload,
+Depends: ${misc:Depends}, ${python3:Depends}, python3-typedload (>= 2),
  python3-websocket, python3-requests, python3-attr
 Description: IRC gateway for slack, running on localhost for one user
  This project is a replacement for slack's IRC gateway that they dropped.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 attrs
 requests
-typedload
+typedload>=2
 websocket-client


### PR DESCRIPTION
It will fail if people use older versions that are around on
ubuntu and debian or their manual installs.

This will force them to upgrade before localslackirc fails to work.