### PR TITLE
Pick the debian-only fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,13 @@ localslackirc (1.10-1) UNRELEASED; urgency=medium
 
   * New upstream release
 
- -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Tue, 28 Apr 2020 21:35:01 +0200
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Thu, 30 Apr 2020 16:06:15 +0200
+
+localslackirc (1.9-2) unstable; urgency=high
+
+  * Add needed build-deps (Closes: #959089)
+
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Thu, 30 Apr 2020 15:56:23 +0200
 
 localslackirc (1.9-1) unstable; urgency=high
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>
 Build-Depends: debhelper (>= 12), python3, dh-python, python3-distutils,
- mypy, python3-typedload (>= 2)
+ mypy, python3-typedload (>= 2), python3-websocket, python3-requests
 Standards-Version: 4.5.0
 Homepage: https://github.com/ltworf/localslackirc
 X-Python3-Version: >= 3.8


### PR DESCRIPTION
Had to do a debian release because i made a mistake.

Basically with make test, unlike mypy, everything gets imported for
real, so the modules are needed also on the build agent.