### PR TITLE
Do not insert mentions in URLs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.10
+* Do not insert mentions inside URLs
 
 1.9
 * Chat history is held and injected when the IRC client is ready

--- a/irc.py
+++ b/irc.py
@@ -378,14 +378,14 @@ class Client:
 
         matches = list(re.finditer(regex, msg))
         matches.reverse() # I want to replace from end to start or the positions get broken
-        for i in matches:
-            username = i.string[i.start():i.end()]
+        for m in matches:
+            username = m.string[m.start():m.end()]
             if username.startswith('://'):
                 continue # Match inside a url
             elif self.provider == Provider.SLACK:
-                msg = msg[0:i.start()] + '<@%s>' % self.sl_client.get_user_by_name(username).id + msg[i.end():]
+                msg = msg[0:m.start()] + '<@%s>' % self.sl_client.get_user_by_name(username).id + msg[m.end():]
             elif self.provider == Provider.ROCKETCHAT:
-                msg = msg[0:i.start()] + f'@{username}' + msg[i.end():]
+                msg = msg[0:m.start()] + f'@{username}' + msg[m.end():]
         return msg
 
     def parse_message(self, msg: str) -> Iterator[bytes]:

--- a/irc.py
+++ b/irc.py
@@ -43,7 +43,7 @@ from log import *
 # How slack expresses mentioning users
 _MENTIONS_REGEXP = re.compile(r'<@([0-9A-Za-z]+)>')
 _CHANNEL_MENTIONS_REGEXP = re.compile(r'<#[A-Z0-9]+\|([A-Z0-9\-a-z]+)>')
-_URL_REGEXP=re.compile(r'<([a-z0-9\-\.]+)://([^\s\|]+)[\|]{0,1}([^<>]*)>')
+_URL_REGEXP = re.compile(r'<([a-z0-9\-\.]+)://([^\s\|]+)[\|]{0,1}([^<>]*)>')
 
 
 _SLACK_SUBSTITUTIONS = [

--- a/irc.py
+++ b/irc.py
@@ -382,6 +382,7 @@ class Client:
             assert regex
         else:
             usernames = self.sl_client.get_usernames()
+            assert usernames
             self._magic_users_id = id(usernames)
             regexs = (r'((://\S*){0,1}\b%s\b)' % username for username in usernames)
             regex = re.compile('|'.join(regexs))

--- a/slack.py
+++ b/slack.py
@@ -606,6 +606,7 @@ class Slack:
     def get_user_by_name(self, name: str) -> User:
         return self._usermapcache[name]
 
+    @lru_cache
     def get_usernames(self) -> List[str]:
         return list(self._usermapcache.keys())
 
@@ -619,6 +620,7 @@ class Slack:
             for user in load(r['members'], List[User]):
                 self._usercache[user.id] = user
                 self._usermapcache[user.name] = user
+            self.get_usernames.cache_clear()
 
     def get_user(self, id_: str) -> User:
         """
@@ -634,6 +636,8 @@ class Slack:
         if response.ok:
             u = load(r['user'], User)
             self._usercache[id_] = u
+            if u.name not in self._usermapcache:
+                self.get_usernames.cache_clear()
             self._usermapcache[u.name] = u
             return u
         else:


### PR DESCRIPTION
Prior to this mentions were inserted looking for them with a
regex like <word-separator>username<word-separator>

This worked but in the case of http.//username/ it would match.

The new regex searches for an initial and optional sequence of "://"
(to match any url schema) followed by any number of non space characters
and then with the old regex at the end.

So URLs still match but their match is different so they can be skipped.

This further changes the match, instead of creating one regex per username
only one giant one is created, putting in OR all the patterns for all the
usernames.

Because the regex is only ran once the substitution is performed
right to left, in order to preserve the position of the matches.

Closes: #81