### PR TITLE
Tag only users on the same channel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 * Greatly reduced CPU usage
 * Remove support for RocketChat.
   I have no way of testing it and it requires severe changes.
+* Only tag users that are in the same channel
 
 1.10
 * Do not insert mentions inside URLs

--- a/irc.py
+++ b/irc.py
@@ -104,8 +104,6 @@ class Client:
         self.autojoin = autojoin
         self._usersent = False # Used to hold all events until the IRC client sends the initial USER message
         self._held_events: List[slack.SlackEvent] = []
-        self._magic_users_id = 0
-        self._magic_regex: Optional[re.Pattern] = None
 
         if self.provider == Provider.SLACK:
             self.substitutions = _SLACK_SUBSTITUTIONS
@@ -239,23 +237,28 @@ class Client:
         else:
             action = False
 
-        message = await self._addmagic(msg.decode('utf8'))
-
         if dest.startswith(b'#'):
+            to_channel = True
+            dest_object: Union[slack.User, slack.Channel] = await self.sl_client.get_channel_by_name(dest[1:].decode())
+        else:
+            to_channel = False
+            dest_object = await self.sl_client.get_user_by_name(dest.decode())
+
+
+        message = await self._addmagic(msg.decode('utf8'), dest_object)
+
+        if to_channel:
             await self.sl_client.send_message(
-                (await self.sl_client.get_channel_by_name(dest[1:].decode())).id,
+                dest_object.id,
                 message,
                 action,
             )
         else:
-            try:
-                await self.sl_client.send_message_to_user(
-                    (await self.sl_client.get_user_by_name(dest.decode())).id,
-                    message,
-                    action,
-                )
-            except Exception:
-                log('Impossible to find user ', dest)
+            await self.sl_client.send_message_to_user(
+                dest_object.id,
+                message,
+                action,
+            )
 
     async def _listhandler(self, cmd: bytes) -> None:
         for c in await self.sl_client.channels(refresh=True):
@@ -396,7 +399,7 @@ class Client:
         ))
         await self.s.drain()
 
-    async def _addmagic(self, msg: str) -> str:
+    async def _addmagic(self, msg: str, dest: Union[slack.User, slack.Channel]) -> str:
         """
         Adds magic codes and various things to
         outgoing messages
@@ -408,18 +411,22 @@ class Client:
             msg = msg.replace('@channel', '<!channel>')
             msg = msg.replace('@everyone', '<!everyone>')
 
+        # No nick substitutions for private chats
+        if isinstance(dest, slack.User):
+            return msg
+
+        usernames = []
+        for j in await self.sl_client.get_members(dest):
+            u = await self.sl_client.get_user(j)
+            usernames.append(u.name)
+
+        if len(usernames) == 0:
+            return msg
+
         # Extremely inefficient code to generate mentions
         # Just doing them client-side on the receiving end is too mainstream
-        if self._magic_users_id == id(self.sl_client.get_usernames()):
-            regex = self._magic_regex
-            assert regex
-        else:
-            usernames = self.sl_client.get_usernames()
-            assert usernames
-            self._magic_users_id = id(usernames)
-            regexs = (r'((://\S*){0,1}\b%s\b)' % username for username in usernames)
-            regex = re.compile('|'.join(regexs))
-            self._magic_regex = regex
+        regexs = (r'((://\S*){0,1}\b%s\b)' % username for username in usernames)
+        regex = re.compile('|'.join(regexs))
 
         matches = list(re.finditer(regex, msg))
         matches.reverse() # I want to replace from end to start or the positions get broken

--- a/irc.py
+++ b/irc.py
@@ -228,8 +228,7 @@ class Client:
 
     async def _privmsghandler(self, cmd: bytes) -> None:
         _, dest, msg = cmd.split(b' ', 2)
-        if msg.startswith(b':'):
-            msg = msg[1:]
+        msg = msg.lstrip(b':')
 
         # Handle sending "/me does something"
         # b'PRIVMSG #much_private :\x01ACTION saluta tutti\x01'

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -99,5 +99,6 @@ class TestMagic(unittest.TestCase):
         dest = Channel('0', '0', None, None)
         assert asyncio.run(self.client._addmagic('ciao LtWorf', dest)) == 'ciao <@LtWorf>'
         assert asyncio.run(self.client._addmagic('LtWorf: ciao', dest)) == '<@LtWorf>: ciao'
+        assert asyncio.run(self.client._addmagic('LtWorf: ciao LtWorf', dest)) == '<@LtWorf>: ciao <@LtWorf>'
         assert asyncio.run(self.client._addmagic('_LtWorf', dest)) == '_LtWorf'
         assert asyncio.run(self.client._addmagic('LtWorf: http://link/user=LtWorf', dest)) == '<@LtWorf>: http://link/user=LtWorf'

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -69,21 +69,6 @@ class TestMagic(unittest.TestCase):
         for i in cases:
             assert asyncio.run(self.client._addmagic(i, dest)) == i
 
-    def test_regex_cache(self):
-        '''
-        Check that the regex is cached and invalidated properly
-        '''
-        return #FIXME there is no cache for now
-        asyncio.run(self.client._addmagic('ciao'))
-        initial = id(self.client._magic_regex)
-        asyncio.run(self.client._addmagic('ciao'))
-        assert initial == id(self.client._magic_regex)
-        asyncio.run(self.client._addmagic('ciao'))
-        assert initial == id(self.client._magic_regex)
-        self.mock_client.usernames = ['myself', 'yourself']
-        asyncio.run(self.client._addmagic('ciao'))
-        assert initial != id(self.client._magic_regex)
-
     def test_escapes(self):
         dest = User('0', 'LtWorf', None)
         assert asyncio.run(self.client._addmagic('<', dest)) == '&lt;'


### PR DESCRIPTION
Refactor how tagging users is done.

Now instead of using a global regexp with all of the users, regexps are created on a per-channel basis and only contain the users in that channel.

On private discussions users are no longer tagged in any case.

To invite users to a channel, the `/invite` command works fine.

Internally, the regexps are cached and reused instead of being recompiled every time. They are automatically dropped when a user joins/leaves a channel.