### PR TITLE
Limit backlog download to 4 days

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -380,6 +380,10 @@ class Slack:
             return
 
         last_timestamp = self._status.last_timestamp
+        FOUR_DAYS = 60 * 60 * 24 * 4
+        if time() - last_timestamp > FOUR_DAYS:
+            log('Last timestamp is too old. Defaulting to 4 days.')
+            last_timestamp = time() - FOUR_DAYS
         dt = datetime.datetime.fromtimestamp(last_timestamp)
         log(f'Last known timestamp {dt}')
 


### PR DESCRIPTION
When the history missing is too much, just download the final 4 days.

This is because otherwise slack will send the older history and then
not send the more recent one.

So I believe it is better to have the recent one instead.

Fixes: https://github.com/ltworf/localslackirc/issues/218