### PR TITLE
Use cursor for conversations.list API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   I have no way of testing it and it requires severe changes.
 * Only tag users that are in the same channel
 * Handle more exceptions with non existing users/channels or malformed commands
+* Handle cursor over conversations list
 
 1.10
 * Do not insert mentions inside URLs


### PR DESCRIPTION
Since slack completely ignores the limit parameter set to 1000, this seems to be needed.

Also, for this API they seem to always send a cursor, but use an empty string, rather than not setting the cursor at all.

Just in case, I test for both things.
