### PR TITLE
Ignore some channels despite autojoin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Only tag users that are in the same channel
 * Handle more exceptions with non existing users/channels or malformed commands
 * Handle cursor over conversations list
+* New setting to not join channels when autojoin is set
 
 1.10
 * Do not insert mentions inside URLs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ a gateway for one user of slack, that can connect to it with whatever IRC
 client they prefer or a bouncer like ZNC and keep using slack from IRC even
 after they shut down their IRC gateway.
 
+Why? Peace of mind!
+-------------------
+
+Using slack from IRC instead of web app offers several advantages:
+
+* You do not see all the gifs other people post.
+* You can `/ignore` users who bother you (can't do that on slack).
+* Leaving channels on slack is hard, normally I get invited back continuously
+  on the off topic channels. With *localslackirc* you can leave them on the IRC
+  client without people knowing that you won't be reading any of that.
+* IRC clients allow to customise notifications. For example I have set mine to
+  just blink in the tray area and do no sounds or popups.
+* Any IRC client is faster than the web ui slack has, and it will respect your
+  colour and style settings.
+* Power savings. Because that's a logical consequence of not doing something
+  in the browser.
+
 Running localslackirc
 =====================
 

--- a/irc.py
+++ b/irc.py
@@ -726,6 +726,8 @@ def main() -> None:
                                 help='Path to the file to keep the internal status.')
     parser.add_argument('--log-suffix', type=str, action='store', dest='log_suffix', default='',
                                 help='Set a suffix for the syslog identifier')
+    parser.add_argument('--ignored-channels', type=str, action='store', dest='ignored_channels', default='',
+                                help='Comma separated list of channels to not join when autojoin is enabled')
 
     args = parser.parse_args()
 

--- a/irc.py
+++ b/irc.py
@@ -753,6 +753,17 @@ def main() -> None:
     autojoin: bool = environ['AUTOJOIN'].lower() == 'true' if 'AUTOJOIN' in environ else args.autojoin
     nouserlist: bool = environ['NOUSERLIST'].lower() == 'true' if 'NOUSERLIST' in environ else args.nouserlist
 
+    # Splitting ignored channels
+    ignored_channels_str = environ.get('IGNORED_CHANNELS', args.ignored_channels)
+    if autojoin and len(ignored_channels_str):
+        ignored_channels: Set[bytes] = {
+            (b'' if i.startswith('#') else b'#') + i.encode('ascii')
+            for i in ignored_channels_str.split(',')
+        }
+    else:
+        ignored_channels = set()
+
+
     if 'TOKEN' in environ:
         token = environ['TOKEN']
     else:

--- a/localslackirc.d/example
+++ b/localslackirc.d/example
@@ -39,3 +39,9 @@ AUTOJOIN=true
 
 # Do not fetch the user list (for huge instances)
 #NOUSERLIST=true
+
+# Comma separated list of channels to ignore and not automatically
+# join on IRC.
+# Ignored unless autojoin is set
+# They can be joined again later on with a /join #channel command
+#IGNORED_CHANNELS=#general,#chat

--- a/man/localslackirc.1
+++ b/man/localslackirc.1
@@ -1,4 +1,4 @@
-.TH localslackirc 1 "Jul 5, 2020" "IRC gateway for slack"
+.TH localslackirc 1 "Oct 14, 2020" "IRC gateway for slack"
 .SH NAME
 localslackirc
 \- Creates an IRC server running locally, which acts as a gateway to slack for one user.
@@ -51,6 +51,19 @@ Instead of using localslackirc as ident for syslog, this appends a custom string
 This is useful when running several instances, to be able to distinguish the logs.
 .br
 The default .service file uses this. Of course journald keeps track of the services but this makes it easier to have the information on text dumps or other logging daemons such as rsyslog.
+.TP
+.B --ignored-channels
+Comma separated list of channels to ignore and not automatically join on IRC.
+.br
+It is ignored unless autojoin is set.
+.br
+If a channel is in this list, the IRC client will not automatically join it, but on slack you will still be inside the channel
+.br
+This is useful to avoid off topic channels in which coworkers who can't take a hint keep re-inviting.
+.br
+The ignored channels can be joined again if needed, with a /join #channel command. However the conversation history will not be fetched.
+.br
+For channel names containing non ascii characters, their ascii representation needs to be used. Use /list to see which that is.
 .SH TOKEN
 The access token is (unless specified otherwise) located in ~/.localslackirc, for information on how to obtain your token, check the README file.
 .SH ENVIRONMENT
@@ -90,6 +103,9 @@ Alternative to --nouserlist
 .TP
 .B LOG_SUFFIX
 Alternative to --log-suffix
+.TP
+.B IGNORED_CHANNELS
+Alternative to --ignored-channels
 .SH WEB
 .BR https://github.com/ltworf/localslackirc
 

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -53,7 +53,7 @@ class TestMagic(unittest.TestCase):
                 return User('0', 'LtWorf', None)
 
         self.mock_client = MockClient()
-        self.client = Client(None, self.mock_client, False, True, Provider.SLACK)
+        self.client = Client(None, self.mock_client, False, True, Provider.SLACK, set())
 
     def test_no_replace(self):
         '''


### PR DESCRIPTION
This is to avoid off topic channels in which coworkers will
invite you over and over, no matter if you keep leaving them,
refusing to take the hint that one does not wish to be in that
channel.

The channels will be joined on slack but not joined on IRC, so the
coworkers will be happy, and so will you.

No message will be received from those channels, unless you /join
them again.

In no case will chat history be fetched for those channels.