### PR TITLE
Add note if there are multiple teams when getting token

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Alternatively if this method fails you can get one from Slack's web client
 * In your browser, login to slack and then open the web console.
 * Run this javascript code: `q=JSON.parse(localStorage.localConfig_v2)["teams"]; q[Object.keys(q)[0]]["token"]`
 * Copy the result, without quotes.
+* **Note**: If you are signed in to multiple teams this will not work, run in a private window for the team you want to set up. 
 
 Obtain a Slack cookie
 ---------------------


### PR DESCRIPTION
Was setting up multiple bridges for multiple teams today and found it would give the same token every time (the first one in the list). 

I ended up just dumping the JSON object and getting the tokens that way, but for most users running in a private window would be easy and do the trick.