### PR TITLE
long formatted text into files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.12
+* Option to save long formatted text as .txt files
 
 1.11
 * Greatly reduced CPU usage

--- a/irc.py
+++ b/irc.py
@@ -607,7 +607,12 @@ class Client:
 
                 if formatted.count('\n') > self.settings.formatted_max_lines:
                     import tempfile
-                    with tempfile.NamedTemporaryFile(mode='wt', suffix='.txt', prefix='localslackirc-attachment-', delete=False) as tmpfile:
+                    with tempfile.NamedTemporaryFile(
+                                mode='wt',
+                                dir=self.settings.downloads_directory,
+                                suffix='.txt',
+                                prefix='localslackirc-attachment-',
+                                delete=False) as tmpfile:
                         tmpfile.write(formatted)
                         text = prefix + f'\n === PREFORMATTED TEXT AT file://{tmpfile.name}\n' + suffix
                 else:

--- a/irc.py
+++ b/irc.py
@@ -656,6 +656,7 @@ class Client:
         if not self._usersent:
             self._held_events.append(sl_ev)
             return
+
         if isinstance(sl_ev, slack.MessageDelete):
             await self._message(sl_ev, '[deleted]')
         elif isinstance(sl_ev, slack.Message):

--- a/irc.py
+++ b/irc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # localslackirc
-# Copyright (C) 2018-2020 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2018-2021 Salvo "LtWorf" Tomaselli
 #
 # localslackirc is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/irc.py
+++ b/irc.py
@@ -94,6 +94,7 @@ class ClientSettings(NamedTuple):
     provider: Provider
     ignored_channels: Set[bytes]
     downloads_directory: Path
+    formatted_max_lines: int = 0
 
     def verify(self) -> Optional[str]:
         '''
@@ -747,6 +748,9 @@ def main() -> None:
                                 help='Comma separated list of channels to not join when autojoin is enabled')
     parser.add_argument('--downloads-directory', type=str, action='store', dest='downloads_directory', default='/tmp',
                                 help='Where to create files for automatic downloads')
+    parser.add_argument('--formatted-max-lines', type=int, action='store', dest='formatted_max_lines', default=0,
+                                help='Maximum amount of lines in a formatted text to send to the client rather than store in a file.\n'
+                                'Setting to 0 (the default) will send everything to the client')
 
     args = parser.parse_args()
 
@@ -786,6 +790,14 @@ def main() -> None:
         downloads_directory = Path(environ['DOWNLOADS_DIRECTORY'])
     else:
         downloads_directory = Path(args.downloads_directory)
+
+    if 'FORMATTED_MAX_LINES' in environ:
+        try:
+            formatted_max_lines = int(environ['FORMATTED_MAX_LINES'])
+        except:
+            exit(f'{environ["FORMATTED_MAX_LINES"]} is not an int')
+    else:
+        formatted_max_lines = args.formatted_max_lines
 
     if 'TOKEN' in environ:
         token = environ['TOKEN']
@@ -844,6 +856,7 @@ def main() -> None:
             provider=provider,
             ignored_channels=ignored_channels,
             downloads_directory=downloads_directory,
+            formatted_max_lines=formatted_max_lines,
         )
         verify = clientsettings.verify()
         if verify is not None:

--- a/irc.py
+++ b/irc.py
@@ -93,6 +93,17 @@ class ClientSettings(NamedTuple):
     autojoin: bool
     provider: Provider
     ignored_channels: Set[bytes]
+    downloads_directory: Path
+
+    def verify(self) -> Optional[str]:
+        '''
+        Make sure that the configuration is correct.
+
+        In that case return None. Otherwise an error string.
+        '''
+        if not self.downloads_directory.is_dir():
+            return f'{self.downloads_directory} is not a directory'
+        return None
 
 
 class Client:
@@ -734,6 +745,8 @@ def main() -> None:
                                 help='Set a suffix for the syslog identifier')
     parser.add_argument('--ignored-channels', type=str, action='store', dest='ignored_channels', default='',
                                 help='Comma separated list of channels to not join when autojoin is enabled')
+    parser.add_argument('--downloads-directory', type=str, action='store', dest='downloads_directory', default='/tmp',
+                                help='Where to create files for automatic downloads')
 
     args = parser.parse_args()
 
@@ -769,6 +782,10 @@ def main() -> None:
     else:
         ignored_channels = set()
 
+    if 'DOWNLOADS_DIRECTORY' in environ:
+        downloads_directory = Path(environ['DOWNLOADS_DIRECTORY'])
+    else:
+        downloads_directory = Path(args.downloads_directory)
 
     if 'TOKEN' in environ:
         token = environ['TOKEN']
@@ -826,7 +843,11 @@ def main() -> None:
             autojoin=autojoin,
             provider=provider,
             ignored_channels=ignored_channels,
+            downloads_directory=downloads_directory,
         )
+        verify = clientsettings.verify()
+        if verify is not None:
+            exit(verify)
         ircclient = Client(writer, sl_client, clientsettings)
 
         try:

--- a/localslackirc.d/example
+++ b/localslackirc.d/example
@@ -48,3 +48,10 @@ AUTOJOIN=true
 
 # Where to create files for automatic downloads
 #DOWNLOADS_DIRECTORY=/tmp/
+
+# Maximum amount of lines for formatted messages
+# (the ones with ```) to be allowed within IRC.
+# Messages exceeding the limit will be stored as
+# text files in DOWNLOADS_DIRECTORY.
+# 0 means no limit
+#FORMATTED_MAX_LINES = 0

--- a/localslackirc.d/example
+++ b/localslackirc.d/example
@@ -45,3 +45,6 @@ AUTOJOIN=true
 # Ignored unless autojoin is set
 # They can be joined again later on with a /join #channel command
 #IGNORED_CHANNELS=#general,#chat
+
+# Where to create files for automatic downloads
+#DOWNLOADS_DIRECTORY=/tmp/

--- a/localslackirc.d/example
+++ b/localslackirc.d/example
@@ -46,12 +46,13 @@ AUTOJOIN=true
 # They can be joined again later on with a /join #channel command
 #IGNORED_CHANNELS=#general,#chat
 
-# Where to create files for automatic downloads
+# Where to create files for automatic downloads.
+# Make sure it is writable and has space
 #DOWNLOADS_DIRECTORY=/tmp/
 
-# Maximum amount of lines for formatted messages
-# (the ones with ```) to be allowed within IRC.
-# Messages exceeding the limit will be stored as
-# text files in DOWNLOADS_DIRECTORY.
+# Maximum amount of lines for formatted messages # (the ones with ```) to be
+# allowed within IRC.
+# Messages exceeding the limit will be stored as # text files in
+# DOWNLOADS_DIRECTORY.
 # 0 means no limit
-#FORMATTED_MAX_LINES = 0
+#FORMATTED_MAX_LINES=0

--- a/man/localslackirc.1
+++ b/man/localslackirc.1
@@ -1,4 +1,4 @@
-.TH localslackirc 1 "Oct 27, 2020" "IRC gateway for slack"
+.TH localslackirc 1 "Jan 9, 2021" "IRC gateway for slack"
 .SH NAME
 localslackirc
 \- Creates an IRC server running locally, which acts as a gateway to slack for one user.
@@ -42,6 +42,13 @@ Allow listening on addresses that do not start with 127.*
 .br
 This is potentially dangerous.
 .TP
+.B --downloads-directory
+Where to create files for automatic downloads. It defaults to /tmp.
+.br
+The directory must exist and be writeable. Files will automatically be downloaded in it.
+.br
+No cleaning is automatically performed on it by localslackirc.
+.TP
 .B -f --status-file
 Path to the file keeping the status. When this is set, it allows for the history to be loaded on start.
 .TP
@@ -71,6 +78,9 @@ The following environment variables are used. They override command line setting
 .TP
 .B COOKIE
 Alternative to --cookiefile
+.TP
+.B DOWNLOADS_DIRECTORY
+Alternative to --downloads-directory
 .TP
 .B PORT
 Alternative to --port

--- a/man/localslackirc.1
+++ b/man/localslackirc.1
@@ -1,4 +1,4 @@
-.TH localslackirc 1 "Jan 9, 2021" "IRC gateway for slack"
+.TH localslackirc 1 "Jan 26, 2021" "IRC gateway for slack"
 .SH NAME
 localslackirc
 \- Creates an IRC server running locally, which acts as a gateway to slack for one user.
@@ -48,6 +48,21 @@ Where to create files for automatic downloads. It defaults to /tmp.
 The directory must exist and be writeable. Files will automatically be downloaded in it.
 .br
 No cleaning is automatically performed on it by localslackirc.
+.TP
+.B --formatted-max-lines
+Maximum amount of lines in a formatted text to send to the client rather than store in a file.
+.br
+When people send logs or otherwise long text content as formatted text, the end result is usually hardly readable in IRC, having the username of the sender and the time in each line.
+.br
+This option sets a limit for formatted content to be sent as text.
+.br
+When the limit is exceeded, the formatted text will be stored as a .txt file instead and its URL will be shown in the IRC client.
+.br
+The files will be saved in the path specified by "downloads directory".
+.br
+The files are not automatically removed.
+.br
+Setting to 0 (the default) will send everything to the client and create no text files.
 .TP
 .B -f --status-file
 Path to the file keeping the status. When this is set, it allows for the history to be loaded on start.

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import unittest
+from pathlib import Path
 
 from irc import _MENTIONS_REGEXP, _CHANNEL_MENTIONS_REGEXP, _URL_REGEXP, Client, Provider, ClientSettings
 from slack import Channel, User
@@ -78,6 +79,7 @@ class TestMagic(unittest.TestCase):
             True,
             Provider.SLACK,
             set(),
+            Path('/tmp'),
         )
         self.client = Client(None, self.mock_client, settings)
 

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -1,5 +1,5 @@
 # localslackirc
-# Copyright (C) 2020 Salvo "LtWorf" Tomaselli
+# Copyright (C) 2020-2021 Salvo "LtWorf" Tomaselli
 #
 # localslackirc is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Formatted text longer than a certain amount can now be saved as .txt files in a chosen directory, to be more readable and avoid the wall of text in the chat