### PR TITLE
slack: allow debugging incoming events without hacking the source

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -776,6 +776,8 @@ def main() -> None:
                                 help='allow non 127. addresses, this is potentially dangerous')
     parser.add_argument('-f', '--status-file', type=str, action='store', dest='status_file', required=False, default=None,
                                 help='Path to the file to keep the internal status.')
+    parser.add_argument('-d', '--debug', action='store_true', dest='debug', required=False, default=False,
+                                help='Enables debugging logs.')
     parser.add_argument('--log-suffix', type=str, action='store', dest='log_suffix', default='',
                                 help='Set a suffix for the syslog identifier')
     parser.add_argument('--ignored-channels', type=str, action='store', dest='ignored_channels', default='',
@@ -789,6 +791,7 @@ def main() -> None:
     args = parser.parse_args()
 
     openlog(environ.get('LOG_SUFFIX', args.log_suffix))
+    set_debug(environ.get('DEBUG', args.debug))
 
     status_file_str: Optional[str] = environ.get('STATUS_FILE', args.status_file)
     status_file = None

--- a/localslackirc.d/example
+++ b/localslackirc.d/example
@@ -56,3 +56,6 @@ AUTOJOIN=true
 # DOWNLOADS_DIRECTORY.
 # 0 means no limit
 #FORMATTED_MAX_LINES=0
+
+# Debugging (disabled by default)
+# DEBUG=1

--- a/log.py
+++ b/log.py
@@ -17,16 +17,20 @@
 # author Salvo "LtWorf" Tomaselli <tiposchi@tiscali.it>
 
 from os import isatty
-from syslog import LOG_INFO, syslog
+from syslog import LOG_INFO, LOG_DEBUG, syslog
 from syslog import openlog as _openlog
+from typing import Union
 
 __all__ = [
     'log',
-    'openlog'
+    'openlog',
+    'set_debug',
+    'debug',
 ]
 
 
 tty = isatty(1) and isatty(2)
+debug_enabled = False
 
 
 def openlog(suffix: str) -> None:
@@ -50,3 +54,16 @@ def log(*args) -> None:
         print(*args)
         return
     syslog(LOG_INFO, ' '.join(str(i) for i in args))
+
+
+def set_debug(state: Union[str, bool]) -> None:
+    global debug_enabled
+    debug_enabled = bool(state)
+
+
+def debug(*args) -> None:
+    if not debug_enabled:
+        return
+    if tty:
+        print(*args)
+    syslog(LOG_DEBUG, ' '.join(str(i) for i in args))

--- a/man/localslackirc.1
+++ b/man/localslackirc.1
@@ -67,6 +67,9 @@ Setting to 0 (the default) will send everything to the client and create no text
 .B -f --status-file
 Path to the file keeping the status. When this is set, it allows for the history to be loaded on start.
 .TP
+.B -d --debug
+Enables debugging logs.
+.TP
 .B --log-suffix
 Instead of using localslackirc as ident for syslog, this appends a custom string, separated by a -.
 .br
@@ -122,6 +125,9 @@ Alternative to --autojoin
 .TP
 .B NOUSERLIST
 Alternative to --nouserlist
+.TP
+.B DEBUG
+Alternative to --debug
 .TP
 .B LOG_SUFFIX
 Alternative to --log-suffix

--- a/slack.py
+++ b/slack.py
@@ -834,6 +834,7 @@ class Slack:
             if t in USELESS_EVENTS:
                 continue
 
+            debug(event)
             loadable_events = Union[TopicChange, FileShared, MessageBot, MessageEdit, MessageDelete, GroupJoined, Join, Leave]
             try:
                 ev: Optional[loadable_events] = load(


### PR DESCRIPTION
This avoids having to hack slack.py to debug incoming messages from
slack. Instead, one can just set DEBUG to anything in the configuration
file to turn debugging on.