### PR TITLE
Add new setting for silenced yellers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Unicode emoji!
 * Improved diff
 * Improved compatibility with IRC
+* Able to prevent selected users from abusing general mentions
 
 1.11
 * Greatly reduced CPU usage

--- a/irc.py
+++ b/irc.py
@@ -551,8 +551,8 @@ class Client:
                 i[mention.span()[1]:]
             )
 
-        # Replace all channel mentions
         if self.settings.provider == Provider.SLACK:
+            # Replace all channel mentions
             while True:
                 mention = _CHANNEL_MENTIONS_REGEXP.search(i)
                 if not mention:
@@ -564,6 +564,7 @@ class Client:
                     i[mention.span()[1]:]
                 )
 
+            #Replace URL with bottom links
             bottom = ""
             refs = str.maketrans("0123456789", "⁰¹²³⁴⁵⁶⁷⁸⁹")
             refn = 1

--- a/localslackirc.d/example
+++ b/localslackirc.d/example
@@ -57,5 +57,8 @@ AUTOJOIN=true
 # 0 means no limit
 #FORMATTED_MAX_LINES=0
 
+# Comma separated list of nicknames not allowed to use general mentions
+#SILENCED_YELLERS=rose.adams,alfio.cuttigghiu
+
 # Debugging (disabled by default)
 # DEBUG=1

--- a/man/localslackirc.1
+++ b/man/localslackirc.1
@@ -1,4 +1,4 @@
-.TH localslackirc 1 "Jan 26, 2021" "IRC gateway for slack"
+.TH localslackirc 1 "Apr 24, 2021" "IRC gateway for slack"
 .SH NAME
 localslackirc
 \- Creates an IRC server running locally, which acts as a gateway to slack for one user.
@@ -67,6 +67,13 @@ Setting to 0 (the default) will send everything to the client and create no text
 .B -f --status-file
 Path to the file keeping the status. When this is set, it allows for the history to be loaded on start.
 .TP
+.B --silenced-yellers
+Comma separated list of nicknames that are prevented from using general mentions (@here, @channel, @everyone, and the likes).
+.br
+Since some people are greatly abusing the feature, this is to make them less annoying.
+.br
+Their messages aren't blocked and are shown as "yelling MESSAGE", but the nickname of the user won't be injected in the message, so the IRC client won't create a notification.
+.TP
 .B -d --debug
 Enables debugging logs.
 .TP
@@ -134,6 +141,9 @@ Alternative to --log-suffix
 .TP
 .B IGNORED_CHANNELS
 Alternative to --ignored-channels
+.TP
+.B SILENCED_YELLERS
+Alternative to --silenced-yellers
 .SH WEB
 .BR https://github.com/ltworf/localslackirc
 

--- a/tests/test_irc.py
+++ b/tests/test_irc.py
@@ -32,15 +32,15 @@ def b(s: str) -> bytes:
 
 class TestParseMessage(TestIRC):
     async def test_simple_message(self):
-        msg = await self.client.parse_message("hello world")
+        msg = await self.client.parse_message("hello world", b'ciccio')
         self.assertEqual(msg, b"hello world")
 
     async def test_url(self):
-        msg = await self.client.parse_message("See <https://example.com/docs/|the documentation>")
+        msg = await self.client.parse_message("See <https://example.com/docs/|the documentation>", b'ciccio')
         self.assertEqual(msg, b("See the documentation¹\n  ¹ https://example.com/docs/"))
 
     async def test_multiple_urls(self):
-        msg = await self.client.parse_message("See <https://example.com/docs/|the documentation>. Try also the <https://example.com/faq/|FAQ>")
+        msg = await self.client.parse_message("See <https://example.com/docs/|the documentation>. Try also the <https://example.com/faq/|FAQ>", b'ciccio')
         self.assertEqual(msg, b("See the documentation¹. Try also the FAQ²\n  ¹ https://example.com/docs/\n  ² https://example.com/faq/"))
 
     async def test_a_lot_of_urls(self):
@@ -58,9 +58,9 @@ class TestParseMessage(TestIRC):
             "  ⁹ https://example.com/",
             "  ¹⁰ https://example.com/",
         ])
-        msg = await self.client.parse_message(input_msg)
+        msg = await self.client.parse_message(input_msg, b'ciccio')
         self.assertEqual(msg, b(output))
 
     async def test_url_with_no_label_just_goes_inline(self):
-        msg = await self.client.parse_message("Please look at <https://example.com/>")
+        msg = await self.client.parse_message("Please look at <https://example.com/>", b'ciccio')
         self.assertEqual(msg, b("Please look at https://example.com/"))

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -79,6 +79,7 @@ class TestMagic(unittest.TestCase):
             True,
             Provider.SLACK,
             set(),
+            set(),
             Path('/tmp'),
         )
         self.client = Client(None, self.mock_client, settings)


### PR DESCRIPTION
Fixes: #296

Some people can't understand that continuously using @channel mentions
to ask a question to one specific person is somewhat annoying and
distracting.

Since fixing people is much harder than coding, this adds some code to
ignore the general mentions by those people.