### PR TITLE
Pin library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 typedload>=2.6
 emoji
-websockets
+websockets<9.0


### PR DESCRIPTION
Unfortunately, upstream changed API and didn't even
include a changelog.

Well it seems he was not even aware of having changed API.

Anyway for now pin it at least until debian gets released
and upgrades it on debian, then I can just move to the new
one and force version >=9

Fixes: #304