### PR TITLE
irc: don't expand URLs with no meaningful label

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -574,7 +574,7 @@ class Client:
                 if not url:
                     break
                 schema, path, label = url.groups()
-                if label:
+                if label and (label != f"{schema}://{path}"):
                     ref = str(refn).translate(refs)
                     refn += 1
                     i = (

--- a/tests/test_irc.py
+++ b/tests/test_irc.py
@@ -84,3 +84,7 @@ class TestParseMessage(TestIRC):
     async def test_url_with_no_label_just_goes_inline(self):
         msg = await self.client.parse_message("Please look at <https://example.com/>", b'ciccio')
         self.assertEqual(msg, b("Please look at https://example.com/"))
+
+    async def test_dont_expand_urls_with_no_different_text(self):
+        msg = await self.client.parse_message("<https://example.com/|https://example.com/>", b'ciccio')
+        self.assertEqual(msg, b"https://example.com/")


### PR DESCRIPTION
Sometimes URLs come with a label that is exactly the same URL again.
Don't expand those URLs as label¹, then ¹ URL because that is just
unecessary noise.