### PR TITLE
Add debian testsuite

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 localslackirc (1.13-1) UNRELEASED; urgency=medium
 
   * New upstream release
+  * Add debian tests (run the testsuite and localslackirc --help)
 
  -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Mon, 23 Aug 2021 09:17:52 +0200
 

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,6 @@
+Test-Command: make test
+Depends: mypy
+Restrictions: allow-stderr
+
+Test-Command: ./localslackirc --help
+Restrictions: superficial


### PR DESCRIPTION
Tests failing can block mypy from migrating, thus preventing the usual FTBFS error