### PR TITLE
Refactor handling of attached files

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -696,6 +696,10 @@ class Client:
 
         text = sl_ev.text
 
+        if sl_ev.files:
+            for f in sl_ev.files:
+                text+=f'\n[file upload] {f.name}\n{f.mimetype} {f.size} bytes\n{f.url_private}'
+
         lines = await self.parse_message(prefix + text, source)
         for i in lines.split(b'\n'):
             if not i:
@@ -749,9 +753,6 @@ class Client:
                 await self._message(sl_ev.diffmsg)
         elif isinstance(sl_ev, slack.MessageBot):
             await self._message(sl_ev, '[%s] ' % sl_ev.username)
-        elif isinstance(sl_ev, slack.FileShared):
-            f = await self.sl_client.get_file(sl_ev)
-            await self._message(f.announce())
         elif isinstance(sl_ev, slack.Join):
             await self._joined_parted(sl_ev, True)
         elif isinstance(sl_ev, slack.Leave):


### PR DESCRIPTION
Basically the file shared event contains information about which channel is receiving the file but not
if the file is referenced into a thread or in the main channel.

This changes a bunch of things.

No longer handle the FileShared event at all, but instead read the files field in messages and
get the links from there.

So the announce is no longer needed to create a fake message and file_shared events are ignored.

Doing this, automatically the shared files end up in their right place.

Also the call to get file information is no longer needed and was removed.

Closes: #342