### PR TITLE
Point release to fix autopkgtest

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+localslackirc (1.15-3) unstable; urgency=medium
+
+  * Fix the fix with autopkgtest
+
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Sun, 05 Jun 2022 09:09:53 +0200
+
+localslackirc (1.15-2) unstable; urgency=medium
+
+  * Fix autotest
+
+ -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Sun, 05 Jun 2022 01:09:02 +0200
+
 localslackirc (1.15-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,5 +1,6 @@
 Test-Command: export PYTHONPATH=/usr/share/localslackirc && cp -r tests $AUTOPKGTEST_TMP && cd $AUTOPKGTEST_TMP && python3 -m tests
 Restrictions: allow-stderr
+Depends: python3-emoji, localslackirc
 
 Test-Command: ./localslackirc --help
 Restrictions: superficial


### PR DESCRIPTION
Not tagging it, binary is unchanged.