### PR TITLE
Improve handling of unix signals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.17
+* Improve handling of UNIX signals
 
 1.16
 * Can ignore yelling (@here and such) for entire channels

--- a/irc.py
+++ b/irc.py
@@ -946,6 +946,8 @@ def main() -> None:
     # Parameters are dealt with
 
     async def irc_listener() -> None:
+        loop = asyncio.get_running_loop()
+
         serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         serversocket.bind((ip, port))
@@ -953,9 +955,9 @@ def main() -> None:
 
         s, _ = serversocket.accept()
         serversocket.close()
-        asyncio.get_running_loop().add_signal_handler(signal.SIGHUP, term_f)
-        asyncio.get_running_loop().add_signal_handler(signal.SIGTERM, term_f)
-        asyncio.get_running_loop().add_signal_handler(signal.SIGINT, term_f)
+        loop.add_signal_handler(signal.SIGHUP, term_f)
+        loop.add_signal_handler(signal.SIGTERM, term_f)
+        loop.add_signal_handler(signal.SIGINT, term_f)
         reader, writer = await asyncio.open_connection(sock=s)
 
         previous_status = None

--- a/irc.py
+++ b/irc.py
@@ -952,6 +952,7 @@ def main() -> None:
         serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         serversocket.bind((ip, port))
         serversocket.listen(1)
+        serversocket.setblocking(False)
 
         s, _ = await loop.sock_accept(serversocket)
         serversocket.close()

--- a/irc.py
+++ b/irc.py
@@ -998,9 +998,6 @@ def main() -> None:
             to_irc_task.cancel()
 
     while True:
-        signal.signal(signal.SIGHUP, term_f)
-        signal.signal(signal.SIGTERM, term_f)
-        signal.signal(signal.SIGINT, term_f)
         try:
             asyncio.run(irc_listener())
         except IrcDisconnectError:

--- a/irc.py
+++ b/irc.py
@@ -953,7 +953,7 @@ def main() -> None:
         serversocket.bind((ip, port))
         serversocket.listen(1)
 
-        s, _ = serversocket.accept()
+        s, _ = await loop.sock_accept(serversocket)
         serversocket.close()
         loop.add_signal_handler(signal.SIGHUP, term_f)
         loop.add_signal_handler(signal.SIGTERM, term_f)

--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -124,7 +124,7 @@ class SlackClient:
             timeout: in seconds
         """
         r = await self.login()
-        self._websocket = await wsconnect(r.url)
+        self._websocket = await wsconnect(r.url, close_timeout=0.2)
         return r
 
 


### PR DESCRIPTION
Just always use asyncio signals.

Do not block the async loop when waiting for a connection.

Always use the same async loop, do not end it to start a new one when
the irc client reconnects.

Make the websocket closing timeout very small, or that hangs termination
for 10 seconds for no useful reason.