### PR TITLE
Prevent loop when processing history

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -488,7 +488,10 @@ class Slack:
                         ))
 
                 if response.has_more and response.response_metadata:
-                    cursor = response.response_metadata.next_cursor
+                    next_cursor = response.response_metadata.next_cursor
+                    if next_cursor == cursor:
+                        break
+                    cursor = next_cursor
                 else:
                     break
 


### PR DESCRIPTION
I was seeing an infinite loop when localslackirc was trying to display the history from a particularly busy channel. After adding some debugging log calls in there, I noticed that the same cursos was being returned over and over, causing an infinite loop.