### PR TITLE
fix compatibility when python3-emoji isn't installed

### DIFF
--- a/msgparsing.py
+++ b/msgparsing.py
@@ -22,7 +22,7 @@ from typing import Iterable, NamedTuple, Optional
 try:
     from emoji import emojize  # type: ignore
 except ModuleNotFoundError:
-    def emojize(string:str, use_aliases:bool=False, delimiters: tuple[str,str]=(':', ':')) -> str:  # type: ignore
+    def emojize(string:str, *args, **kwargs) -> str:  # type: ignore
         return string
 
 


### PR DESCRIPTION
We call `emojize` with a `language` argument not handled in the dummy definition of the function. To prevent other problems in future, ignore every other arguments than `string`.