### PR TITLE
Fix passing websocket connection timeout on RTM reconnects

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -123,7 +123,7 @@ class SlackClient:
         :Args:
             timeout: in seconds
         """
-        r = await self.login()
+        r = await self.login(timeout=timeout)
         headers = {
             'user-agent': 'localslackirc',
             'Authorization': f'Bearer {self._token}',


### PR DESCRIPTION
Hi,

I've had localslackirc crash with the following backtrace:
```
Traceback (most recent call last):
  File "_venv/lib/python3.10/site-packages/websockets/legacy/protocol.py", line 959, in transfer_data
    message = await self.read_message()
  File "_venv/lib/python3.10/site-packages/websockets/legacy/protocol.py", line 1029, in read_message
    frame = await self.read_data_frame(max_size=self.max_size)
  File "_venv/lib/python3.10/site-packages/websockets/legacy/protocol.py", line 1104, in read_data_frame
    frame = await self.read_frame(max_size)
  File "_venv/lib/python3.10/site-packages/websockets/legacy/protocol.py", line 1161, in read_frame
    frame = await Frame.read(
  File "_venv/lib/python3.10/site-packages/websockets/legacy/framing.py", line 68, in read
    data = await reader(2)
  File "/usr/lib/python3.10/asyncio/streams.py", line 707, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/lib/python3.10/asyncio/streams.py", line 501, in _wait_for_data
    await self._waiter
asyncio.exceptions.CancelledError
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "localslackirc/slack.py", line 857, in event
    events = await self.client.rtm_read()
  File "localslackirc/slackclient/client.py", line 174, in rtm_read
    json_data: str = await self._websocket.recv()  # type: ignore
  File "_venv/lib/python3.10/site-packages/websockets/legacy/protocol.py", line 568, in recv
    await self.ensure_open()
  File "_venv/lib/python3.10/site-packages/websockets/legacy/protocol.py", line 944, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: sent 1011 (unexpected error) keepalive ping timeout; no close frame received
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "localslackirc/localslackirc", line 24, in <module>
    main()
  File "localslackirc/irc.py", line 1057, in main
    asyncio.run(restart_listener_loop())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "localslackirc/irc.py", line 1053, in restart_listener_loop
    await irc_listener()
  File "localslackirc/irc.py", line 1029, in irc_listener
    await asyncio.gather(
  File "localslackirc/irc.py", line 1071, in to_irc
    ev = await sl_client.event()
  File "localslackirc/slack.py", line 860, in event
    self.login_info = await self.client.rtm_connect(5)
asyncio.exceptions.TimeoutError
```

Which seem to be somewhat expected behavior, but looking a bit into it, found that "5" in `rtm_connect(5)` seem to be a timeout value that is not actually used. This PR should fix that.

I think more generally, it might also make sense to create e.g. SlackSettings tuple in slack.py, something like:

```python
class SlackSettings(NamedTuple):
  token: str
  cookie: Optional[str]
  connect_timeout: int = 15
```

With the idea to set connect_timeout and allow for other slack-related tunables, because default timeout=5 might not be sufficient with e.g. my internet connection, and needs to be changed somehow.

And then probably pass that tuple around slack classes as `self.settings`, instead of e.g. `self.client = SlackClient(token=..., cookie=..., other_duplicated_key_spec=...)`, to avoid unnecessary duplication and allow adding/changing such options easily.

Do you think it'd make sense to implement like that, or maybe prefer another way of handling configuration?
Was thinking to maybe add it, if these timeouts prove to be a bothersome issue.

Thanks!
