### PR TITLE
Remove the quotes for the env vars in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ So, for example (the real values will be longer):
 
 ```
 TOKEN=xoxc-1111111
-COOKIE="d=xoxd-1111111;"
+COOKIE=d=xoxd-1111111;
 ```
+
+Remember to quote if you pass them in a shell.
 
 Using localslackirc
 ===================


### PR DESCRIPTION
That is because unlike systemd, docker just passes them and then nothing works.

I have tried on my machine and it seems that systemd env file works fine even without quotes, so it should be ok.

Fixes: #456